### PR TITLE
Update documentation and build scripts.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,21 @@ This repository contains examples (and errata) for [Learning Hadoop 2](http://le
 ## Requirements
 
 Throughout the book we use Cloudera CDH 5.0 and Amazon EMR as reference systems. All examples target, 
-and have been tested with, Java 7.
+and have been tested with Java 7.
 
-## Build the examples
-The easiest way to build the examples, with CDH 5.0 dependencies, is to use the provided Gradle and sbt scripts.
+**Update (2021-05-16):** as of February 2021 Cloudera CDH is not available to the general public anymore. 
+
+More information about the transition to private repositories can be found at https://community.cloudera.com/t5/Product-Announcements/Transition-to-private-repositories-for-CDH-HDP-and-HDF/td-p/311064.
+
+### Building the examples
+While (some) jar dependencies are still available at [https://repository.cloudera.com/artifactory/cloudera-repos/](https://repository.cloudera.com/artifactory/cloudera-repos/), we updated the chapters build scripts to use vanilla version of the dependencies available through regular maven channels.
+
+### Running the examples
+
+Alternatives to the (virtualized) Hadoop environment that was provided by CDH VM are avaialble at:
+ * [Cloudera Hortonworks Sandbox](https://www.cloudera.com/downloads/hortonworks-sandbox.html).
+ * [BDE docker deployment](https://github.com/big-data-europe/docker-hadoop).
+ * [Apache Big Top](https://bigtop.apache.org/)
 
 ### Gradle
 We use [Gradle](https://gradle.org) to compile Java code and collect the required class files into a single JAR file.
@@ -71,12 +82,7 @@ Or, it can be packaged into a JAR file with:
 $ sbt package
 ```
 
-For Spark in standalone mode, an helper script to execute compiled classes can be generated with:
-```{bash}
-$ sbt add-start-script-tasks
-$ sbt start-script
-```
-The helper can be invoked as follows:
+And run with
 
 ```{bash}
 $ target/start <class name> <master> <param1> … <param n>
@@ -85,7 +91,7 @@ $ target/start <class name> <master> <param1> … <param n>
 
 #### YARN on CDH5
 
-To run the examples on a YARN grid on CDH5, you can build a JAR file using:
+To run the examples on a YARN grid, you can build a JAR file using:
 ```{bash}
 $ sbt package
 ```

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ More information about the transition to private repositories can be found at ht
 ### Building the examples
 While (some) jar dependencies are still available at [https://repository.cloudera.com/artifactory/cloudera-repos/](https://repository.cloudera.com/artifactory/cloudera-repos/), we updated the chapters build scripts to use vanilla version of the dependencies available through regular maven channels.
 
+The updated build scripts have been tested with Java 8 on the [AdoptOpenJDK](https://adoptopenjdk.net/) virtual machine.
+
+Original codes and build scripts can be found at https://github.com/learninghadoop2/book-examples/releases/tag/v1.0.0.
+
 ### Running the examples
 
 Alternatives to the (virtualized) Hadoop environment that was provided by CDH VM are avaialble at:

--- a/ch2/build.gradle
+++ b/ch2/build.gradle
@@ -1,23 +1,22 @@
 apply plugin:'java'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
 repositories{
-mavenCentral()
-
-    // Required for Kafka/Samza.
     maven {
-      url 'https://repository.apache.org/content/groups/public'
+        url = 'https://repo1.maven.org/maven2/'
     }
 }
 
 dependencies {
-compile 'org.apache.avro:avro:1.7.7'
+    compile 'org.apache.avro:avro:1.7.7'
 }
 
-  task run(type:JavaExec) {
+task run(type:JavaExec) {
     main = 'com.learninghadoop2.avro.AvroParse'
- classpath = sourceSets.main.runtimeClasspath
+    classpath = sourceSets.main.runtimeClasspath
 }
 
 task wrapper(type: Wrapper) {
-gradleVersion '2.0'
+    gradleVersion '2.0'
 }

--- a/ch3/build.gradle
+++ b/ch3/build.gradle
@@ -1,20 +1,23 @@
 apply plugin:'java'
+sourceCompatibility = 1.8
+targetCompatibility = 1.8
 
-repositories{
-mavenCentral()
-    maven {
-      url 'https://repository.cloudera.com/artifactory/cloudera-repos/'
-    }
+// Use maven central (over https) instead of Cloudera repos
+repositories {
+   maven {
+      url = 'https://repo1.maven.org/maven2/'
+   }
 }
+
+// Drop -cdh5.0.3 versions of Hadoop pacakges. Use vanilla version instead. 
 dependencies {
-compile 'org.kitesdk:kite-data-core:0.17.0'
-compile 'org.kitesdk:kite-morphlines-core:0.17.0'
-compile 'org.apache.hadoop:hadoop-common:2.3.0-cdh5.0.3'
-compile 'org.apache.hadoop:hadoop-mapreduce-client-core:2.3.0-cdh5.0.3'
-compile 'org.apache.hadoop:hadoop-mapreduce-client-common:2.3.0-cdh5.0.3'
-compile 'org.apache.hive.hcatalog:hive-hcatalog-core:0.12.0-cdh5.0.0'
-compile 'org.apache.hive:hive-metastore:0.12.0-cdh5.0.0'
+   compile 'org.kitesdk:kite-data-core:0.17.0'
+   compile 'org.kitesdk:kite-morphlines-core:0.17.0'
+   compile 'org.apache.hadoop:hadoop-common:2.3.0'
+   compile 'org.apache.hadoop:hadoop-mapreduce-client-core:2.3.0'
+   compile 'org.apache.hadoop:hadoop-mapreduce-client-common:2.3.0'
+   compile 'org.apache.hive.hcatalog:hive-hcatalog-core:0.13.0' // 0.12 is not available on mavencentral
+   compile 'org.apache.hive:hive-metastore:0.13.0' // upgrade 0.12 -> 0.13 to match hive-hcatalog-core
 
-testCompile  "junit:junit:4.0+"
+   testCompile  "junit:junit:4.0+"
 }
-

--- a/ch4/build.gradle
+++ b/ch4/build.gradle
@@ -19,8 +19,10 @@ slf4jVersion = "1.7.7"
 deploy
   }
 
-repositories{
-mavenCentral()
+repositories{ 
+    maven {
+      url = 'https://repo1.maven.org/maven2/'
+    }
 
     // Required for Kafka/Samza.
     maven {

--- a/ch5/build.sbt
+++ b/ch5/build.sbt
@@ -1,6 +1,4 @@
-import com.typesafe.sbt.SbtStartScript
-
-seq(SbtStartScript.startScriptForClassesSettings: _*)
+enablePlugins(JavaAppPackaging)
 
 name := "Chapter 4"
 
@@ -8,7 +6,7 @@ version := "1.0"
 
 scalaVersion := "2.10.3"
 
-resolvers += "Typesafe Repo" at "http://repo.typesafe.com/typesafe/releases/"
+resolvers += "Typesafe Repo" at "https://srepo.typesafe.com/typesafe/releases/"
 
 //libraryDependencies += "play" % "play_2.10" % "2.1.0"
 libraryDependencies += "com.google.code.gson" % "gson" % "2.2.2"
@@ -23,7 +21,7 @@ libraryDependencies += "org.apache.spark" %% "spark-mllib" % "1.1.0"
 
 libraryDependencies += "org.apache.spark" %% "spark-sql" % "1.1.0"
 
-resolvers += "Akka Repository" at "http://repo.akka.io/releases/"
+resolvers += "Akka Repository" at "https://repo.akka.io/releases/"
 
 libraryDependencies += "org.apache.hadoop" % "hadoop-client" % "1.2.1"
 

--- a/ch5/project/plugins.sbt
+++ b/ch5/project/plugins.sbt
@@ -1,1 +1,1 @@
-addSbtPlugin("com.typesafe.sbt" % "sbt-start-script" % "0.10.0")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.6")

--- a/ch9/crunch/build.gradle
+++ b/ch9/crunch/build.gradle
@@ -1,15 +1,19 @@
 apply plugin:'java'
 
 repositories{
-mavenCentral()
-    maven {
+   maven {
+      url = 'https://repo1.maven.org/maven2/'
+   }
+
+   maven {
       url 'https://repository.cloudera.com/artifactory/cloudera-repos/'
-    }
+   }
 }
 dependencies {
-compile 'org.apache.crunch:crunch-core:0.9.0-cdh5.0.3'
-compile 'org.apache.hadoop:hadoop-common:2.3.0-cdh5.0.3'
-
+compile 'org.apache.hadoop:hadoop-common:2.3.0'
+compile 'org.apache.hadoop:hadoop-mapreduce-client-core:2.3.0'
+compile 'org.apache.hadoop:hadoop-mapreduce-client-common:2.3.0'
+compile 'org.apache.crunch:crunch-core:0.9.0'
 
 compile 'com.googlecode.json-simple:json-simple:1.1.1'
 }

--- a/ch9/kite/build.gradle
+++ b/ch9/kite/build.gradle
@@ -1,21 +1,20 @@
 apply plugin:'java'
 
 repositories{
-mavenCentral()
-    maven {
-      url 'https://repository.cloudera.com/artifactory/cloudera-repos/'
-    }
+   maven {
+      url = 'https://repo1.maven.org/maven2/'
+   }
 }
 dependencies {
 compile 'org.kitesdk:kite-data-core:0.17.0'
 compile 'org.kitesdk:kite-data-hive:0.17.0'
 compile 'org.kitesdk:kite-morphlines-core:0.17.0'
 compile 'org.kitesdk:kite-morphlines-json:0.17.0'
-compile 'org.apache.hadoop:hadoop-common:2.3.0-cdh5.0.3'
-compile 'org.apache.hadoop:hadoop-mapreduce-client-core:2.3.0-cdh5.0.3'
-compile 'org.apache.hadoop:hadoop-mapreduce-client-common:2.3.0-cdh5.0.3'
-compile 'org.apache.hive.hcatalog:hive-hcatalog-core:0.12.0-cdh5.0.0'
-compile 'org.apache.hive:hive-metastore:0.12.0-cdh5.0.0'
+compile 'org.apache.hadoop:hadoop-common:2.3.0'
+compile 'org.apache.hadoop:hadoop-mapreduce-client-core:2.3.0'
+compile 'org.apache.hadoop:hadoop-mapreduce-client-common:2.3.0'
+compile 'org.apache.hive.hcatalog:hive-hcatalog-core:0.13.0' // 0.12 is not available on mavencentral
+compile 'org.apache.hive:hive-metastore:0.13.0' // upgrade 0.12 -> 0.13 to match hive-hcatalog-core
 'com.fasterxml.jackson.core:jackson-databind:2.4.3'
 
 }


### PR DESCRIPTION
This PR updates the README with alternatives to CDH, and build scripts to support LTS versions of the Java.

As of February 2021 Cloudera CDH is not available to the general public anymore.
More information about the transition to private repositories can be found at https://community.cloudera.com/t5/Product-Announcements/Transition-to-private-repositories-for-CDH-HDP-and-HDF/td-p/311064.

Readers of the book will have to rely on alternative methods for running the examples

To support more recent distributions and Java virtual machines, gradle and sbt build scripts have been updated to:
1. Use the secure protocol version (https) of Maven repos.
2. Use vanilla Hadoop jar instead of `-cdh5` releases. While not strictly necessary (https://repository.cloudera.com is still public), this should future proof the codes, or at least facilitate upgrade paths.

The updated build scripts have been tested on OpenJDK 1.8.